### PR TITLE
Add real-time order notifications and seller acceptance

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,15 +1,14 @@
 package main
 
 import (
-	"fmt"
-	"github.com/albus-droid/Capstone-Project-Backend/internal/event"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/auth"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/db"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/image_store"
 	"github.com/albus-droid/Capstone-Project-Backend/internal/listing"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/notification"
 	"github.com/albus-droid/Capstone-Project-Backend/internal/order"
 	"github.com/albus-droid/Capstone-Project-Backend/internal/seller"
 	"github.com/albus-droid/Capstone-Project-Backend/internal/user"
-	"github.com/albus-droid/Capstone-Project-Backend/internal/db"
-	"github.com/albus-droid/Capstone-Project-Backend/internal/auth"
-	"github.com/albus-droid/Capstone-Project-Backend/internal/image_store"
 
 	"github.com/gin-gonic/gin"
 )
@@ -19,9 +18,9 @@ func main() {
 	db := db.Init()
 	redisStore := auth.NewRedisStore("redis:6379", "", 0)
 	minioClient, err := image_store.NewMinioClientFromEnv()
-    if err != nil {
-        panic(err)
-    }
+	if err != nil {
+		panic(err)
+	}
 
 	// user routes
 	user.Migrate(db) // optional for dev
@@ -43,23 +42,9 @@ func main() {
 	osvc := order.NewPostgresService(db)
 	order.RegisterRoutes(r, osvc)
 
-	startNotificationListener()
+	nm := notification.NewManager(db)
+	nm.RegisterRoutes(r)
+	go nm.Run()
+
 	r.Run(":8000") // http://localhost:8080
-}
-
-func startNotificationListener() {
-	go func() {
-		for e := range event.Bus {
-			switch e.Type {
-
-			case "OrderPlaced":
-				order := e.Data.(order.Order)
-				fmt.Printf("📦 Notify seller %s of new order %s\n", order.SellerID, order.ID)
-
-			case "OrderAccepted":
-				order := e.Data.(order.Order)
-				fmt.Printf("📬 Notify user %s that order %s was accepted\n", order.UserEmail, order.ID)
-			}
-		}
-	}()
 }

--- a/internal/notification/manager.go
+++ b/internal/notification/manager.go
@@ -1,0 +1,118 @@
+package notification
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/albus-droid/Capstone-Project-Backend/internal/auth"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/event"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/order"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/seller"
+)
+
+type Manager struct {
+	db      *gorm.DB
+	mu      sync.Mutex
+	sellers map[string][]chan event.Event // sellerID -> channels
+	users   map[string][]chan event.Event // userEmail -> channels
+}
+
+func NewManager(db *gorm.DB) *Manager {
+	return &Manager{
+		db:      db,
+		sellers: make(map[string][]chan event.Event),
+		users:   make(map[string][]chan event.Event),
+	}
+}
+
+func (m *Manager) Run() {
+	for e := range event.Bus {
+		m.mu.Lock()
+		switch e.Type {
+		case "OrderPlaced":
+			o := e.Data.(order.Order)
+			for _, ch := range m.sellers[o.SellerID] {
+				ch <- e
+			}
+		case "OrderAccepted":
+			o := e.Data.(order.Order)
+			for _, ch := range m.users[o.UserEmail] {
+				ch <- e
+			}
+		}
+		m.mu.Unlock()
+	}
+}
+
+func (m *Manager) RegisterRoutes(r *gin.Engine) {
+	grp := r.Group("/notifications")
+	grp.Use(auth.Middleware())
+	grp.GET("", m.handle)
+}
+
+func (m *Manager) handle(c *gin.Context) {
+	email := c.GetString(string(auth.CtxEmailKey))
+
+	var key string
+	var isSeller bool
+	var sl seller.Seller
+	if err := m.db.First(&sl, "email = ?", email).Error; err == nil {
+		key = sl.ID
+		isSeller = true
+	} else {
+		key = email
+	}
+
+	ch := make(chan event.Event, 10)
+
+	m.mu.Lock()
+	if isSeller {
+		m.sellers[key] = append(m.sellers[key], ch)
+	} else {
+		m.users[key] = append(m.users[key], ch)
+	}
+	m.mu.Unlock()
+
+	// Clean up when done
+	defer func() {
+		m.mu.Lock()
+		if isSeller {
+			arr := m.sellers[key]
+			for i, cch := range arr {
+				if cch == ch {
+					m.sellers[key] = append(arr[:i], arr[i+1:]...)
+					break
+				}
+			}
+		} else {
+			arr := m.users[key]
+			for i, cch := range arr {
+				if cch == ch {
+					m.users[key] = append(arr[:i], arr[i+1:]...)
+					break
+				}
+			}
+		}
+		m.mu.Unlock()
+		close(ch)
+	}()
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+
+	c.Stream(func(w io.Writer) bool {
+		select {
+		case ev := <-ch:
+			b, _ := json.Marshal(ev.Data)
+			c.SSEvent(ev.Type, string(b))
+			return true
+		case <-c.Request.Context().Done():
+			return false
+		}
+	})
+}

--- a/internal/order/handler.go
+++ b/internal/order/handler.go
@@ -1,13 +1,13 @@
 package order
 
 import (
-	"net/http"
-	"log"
 	"encoding/json"
 	"errors"
 	"github.com/albus-droid/Capstone-Project-Backend/internal/auth"
 	"github.com/gin-gonic/gin"
 	"gorm.io/datatypes"
+	"log"
+	"net/http"
 )
 
 var ErrOrderAlreadyExists = errors.New("order already exists")
@@ -38,16 +38,16 @@ func RegisterRoutes(r *gin.Engine, svc Service) {
 			Total:      payload.Total,
 		}
 		if err := svc.Create(o); err != nil {
-    		switch {
-    		case errors.Is(err, ErrOrderAlreadyExists):
-        		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
-    		default:
-        		log.Printf("create order failed: %v", err)
-        		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-    		}
-    		return
-    	}
-    	c.JSON(http.StatusCreated, o) // return the order (or a message if you prefer)
+			switch {
+			case errors.Is(err, ErrOrderAlreadyExists):
+				c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+			default:
+				log.Printf("create order failed: %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+		c.JSON(http.StatusCreated, o) // return the order (or a message if you prefer)
 	})
 
 	// ─────────────────────────────────────────────────────────────
@@ -77,7 +77,7 @@ func RegisterRoutes(r *gin.Engine, svc Service) {
 	})
 
 	// ─────────────────────────────────────────────────────────────
-	// PATCH /orders/:id/accept
+	// PATCH /orders/:id/accept – seller accepts an order
 	// ─────────────────────────────────────────────────────────────
 	grp.PATCH("/:id/accept", func(c *gin.Context) {
 		id := c.Param("id")

--- a/internal/order/postgres_service.go
+++ b/internal/order/postgres_service.go
@@ -1,149 +1,158 @@
 package order
 
 import (
-    "errors"
-    "time"
-    "sort"
-    "encoding/json"
-    "github.com/google/uuid"
-    "gorm.io/gorm"
-    "gorm.io/datatypes"
+	"encoding/json"
+	"errors"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"sort"
+	"time"
 
-    "github.com/albus-droid/Capstone-Project-Backend/internal/event"
-    "github.com/albus-droid/Capstone-Project-Backend/internal/listing"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/event"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/listing"
+	"github.com/albus-droid/Capstone-Project-Backend/internal/seller"
 )
 
 type postgresService struct {
-    db *gorm.DB
+	db *gorm.DB
 }
 
 func parseListingIDs(data datatypes.JSON) ([]string, error) {
-    var ids []string
-    err := json.Unmarshal(data, &ids)
-    return ids, err
+	var ids []string
+	err := json.Unmarshal(data, &ids)
+	return ids, err
 }
 
 func NewPostgresService(db *gorm.DB) Service {
-    return &postgresService{db: db}
+	return &postgresService{db: db}
 }
 
 func (s *postgresService) Create(o *Order) error {
-    // 1) assign a fresh ID & timestamp
-    o.ID = uuid.NewString()
-    o.CreatedAt = time.Now().Unix()
-    o.Status = "pending"      // if not already set
+	// 1) assign a fresh ID & timestamp
+	o.ID = uuid.NewString()
+	o.CreatedAt = time.Now().Unix()
+	o.Status = "pending" // if not already set
 
-    // 2) insert—UUID collisions are practically impossible, so no pre‑check needed
-    if err := s.db.Create(o).Error; err != nil {
-        return err
-    }
+	// 2) insert—UUID collisions are practically impossible, so no pre‑check needed
+	if err := s.db.Create(o).Error; err != nil {
+		return err
+	}
 
-    // 3) emit the OrderPlaced event
-    go func(placed Order) {
-        event.Bus <- event.Event{Type: "OrderPlaced", Data: placed}
-    }(*o)
+	// 3) emit the OrderPlaced event
+	go func(placed Order) {
+		event.Bus <- event.Event{Type: "OrderPlaced", Data: placed}
+	}(*o)
 
-    return nil
+	return nil
 }
 
 func (s *postgresService) GetByID(id string) (*Order, error) {
-    var o Order
-    if err := s.db.First(&o, "id = ?", id).Error; err != nil {
-        if errors.Is(err, gorm.ErrRecordNotFound) {
-            return nil, errors.New("order not found")
-        }
-        return nil, err
-    }
-    return &o, nil
+	var o Order
+	if err := s.db.First(&o, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("order not found")
+		}
+		return nil, err
+	}
+	return &o, nil
 }
 
 func (s *postgresService) ListByUser(userEmail string) ([]Order, error) {
-    var list []Order
-    if err := s.db.Where("user_email = ?", userEmail).Find(&list).Error; err != nil {
-        return nil, err
-    }
-    // keep same ordering as in-memory
-    sort.Slice(list, func(i, j int) bool {
-        return list[i].CreatedAt < list[j].CreatedAt
-    })
-    return list, nil
+	var list []Order
+	if err := s.db.Where("user_email = ?", userEmail).Find(&list).Error; err != nil {
+		return nil, err
+	}
+	// keep same ordering as in-memory
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].CreatedAt < list[j].CreatedAt
+	})
+	return list, nil
 }
 
 func (s *postgresService) Accept(id, callerEmail string) error {
-    return s.db.Transaction(func(tx *gorm.DB) error {
-        // Find the order and check user
-        var o Order
-        if err := tx.First(&o, "id = ?", id).Error; err != nil {
-            if errors.Is(err, gorm.ErrRecordNotFound) {
-                return errors.New("order not found")
-            }
-            return err
-        }
-        if o.UserEmail != callerEmail {
-            return errors.New("forbidden")
-        }
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Find the order
+		var o Order
+		if err := tx.First(&o, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return errors.New("order not found")
+			}
+			return err
+		}
 
-        // Parse listing IDs from JSON
-        listingIDs, err := parseListingIDs(o.ListingIDs)
-        if err != nil {
-            return errors.New("invalid listing IDs")
-        }
-        if len(listingIDs) == 0 {
-            return errors.New("no listings in order")
-        }
+		// Verify that caller is the seller associated with the order
+		var sl seller.Seller
+		if err := tx.First(&sl, "email = ?", callerEmail).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return errors.New("seller not found")
+			}
+			return err
+		}
+		if o.SellerID != sl.ID {
+			return errors.New("forbidden")
+		}
 
-        // For each listing ID, decrement left_size if possible
-        for _, lid := range listingIDs {
-            result := tx.Model(&listing.Listing{}).
-                Where("id = ? AND left_size > 0", lid).
-                UpdateColumn("left_size", gorm.Expr("left_size - ?", 1))
-            if result.Error != nil {
-                return result.Error
-            }
-            if result.RowsAffected == 0 {
-                return errors.New("no portions left for listing " + lid)
-            }
-        }
+		// Parse listing IDs from JSON
+		listingIDs, err := parseListingIDs(o.ListingIDs)
+		if err != nil {
+			return errors.New("invalid listing IDs")
+		}
+		if len(listingIDs) == 0 {
+			return errors.New("no listings in order")
+		}
 
-        // Update order status
-        if err := tx.Model(&o).Update("status", "accepted").Error; err != nil {
-            return err
-        }
-        o.Status = "accepted"
+		// For each listing ID, decrement left_size if possible
+		for _, lid := range listingIDs {
+			result := tx.Model(&listing.Listing{}).
+				Where("id = ? AND left_size > 0", lid).
+				UpdateColumn("left_size", gorm.Expr("left_size - ?", 1))
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected == 0 {
+				return errors.New("no portions left for listing " + lid)
+			}
+		}
 
-        // Emit event
-        go func(ev event.Event) {
-            event.Bus <- ev
-        }(event.Event{Type: "OrderAccepted", Data: o})
+		// Update order status
+		if err := tx.Model(&o).Update("status", "accepted").Error; err != nil {
+			return err
+		}
+		o.Status = "accepted"
 
-        return nil
-    })
+		// Emit event
+		go func(ev event.Event) {
+			event.Bus <- ev
+		}(event.Event{Type: "OrderAccepted", Data: o})
+
+		return nil
+	})
 }
 
-
 func (s *postgresService) Complete(id, callerEmail string) error {
-    return s.updateStatus(id, callerEmail, "completed", "OrderCompleted")
+	return s.updateStatus(id, callerEmail, "completed", "OrderCompleted")
 }
 
 func (s *postgresService) updateStatus(id, callerEmail, newStatus, eventType string) error {
-    var o Order
-    if err := s.db.First(&o, "id = ?", id).Error; err != nil {
-        if errors.Is(err, gorm.ErrRecordNotFound) {
-            return errors.New("order not found")
-        }
-        return err
-    }
-    if o.UserEmail != callerEmail {
-        return errors.New("forbidden")
-    }
+	var o Order
+	if err := s.db.First(&o, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errors.New("order not found")
+		}
+		return err
+	}
+	if o.UserEmail != callerEmail {
+		return errors.New("forbidden")
+	}
 
-    if err := s.db.Model(&o).Update("status", newStatus).Error; err != nil {
-        return err
-    }
-    o.Status = newStatus
-    // emit event
-    go func(ev event.Event) {
-       event.Bus <- ev
-    }(event.Event{Type: eventType, Data: o})
-    return nil
+	if err := s.db.Model(&o).Update("status", newStatus).Error; err != nil {
+		return err
+	}
+	o.Status = newStatus
+	// emit event
+	go func(ev event.Event) {
+		event.Bus <- ev
+	}(event.Event{Type: eventType, Data: o})
+	return nil
 }


### PR DESCRIPTION
## Summary
- stream order events to clients via /notifications SSE endpoint
- allow sellers to accept orders and decrement listing portions
- wire up notification manager in main entry point

## Testing
- `go test ./...` *(fails: connection refused / integration tests require running server)*

------
https://chatgpt.com/codex/tasks/task_e_689e7750f4788332962ebf1784add49e